### PR TITLE
Add support for privateKey as a string

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,8 @@ appleSignin.getAuthorizationToken(code, options).then(tokenResponse => {
 });
 ```
 
+It's also possible to pass the private key directly as a string under `privateKey`, instead of passing `privateKeyPath`.
+
 Result of ```getAuthorizationToken``` command is a JSON object representing Apple's [TokenResponse](https://developer.apple.com/documentation/signinwithapplerestapi/tokenresponse):
 ```javascript
 {
@@ -89,6 +91,7 @@ appleSignin.verifyIdToken(tokenResponse.id_token, clientID).then(result => {
     console.log(error);
 });
 ```
+
 ### 4. Refresh access token after expiration
 ```javascript
 
@@ -110,6 +113,8 @@ appleSignin.refreshAuthorizationToken(refreshToken, options).then(result => {
     console.log(error);
 })
 ```
+
+It's also possible to pass the private key directly as a string under `privateKey`, instead of passing `privateKeyPath`.
 
 ## Examples
 Developers using the popular [Express](http://expressjs.com) web framework can refer to an [example](https://github.com/Techofficer/express-apple-signin) as a starting point for their own web applications. 

--- a/source/index.js
+++ b/source/index.js
@@ -33,8 +33,9 @@ const getClientSecret = options => {
   if (!options.clientID) throw new Error('clientID is empty');
   if (!options.teamId) throw new Error('teamId is empty');
   if (!options.keyIdentifier) throw new Error('keyIdentifier is empty');
-  if (!options.privateKeyPath) throw new Error('privateKeyPath is empty');
-  if (!fs.existsSync(options.privateKeyPath)) throw new Error("Can't find private key");
+  if (!options.privateKeyPath && !options.privateKey) throw new Error('privateKey and privateKeyPath are empty');
+  if (options.privateKeyPath && options.privateKey) throw new Error('privateKey and privateKeyPath cannot be passed together, choose one of them');
+  if (options.privateKeyPath && !fs.existsSync(options.privateKeyPath)) throw new Error("Can't find private key");
 
   const timeNow = Math.floor(Date.now() / 1000);
 
@@ -47,7 +48,7 @@ const getClientSecret = options => {
   };
 
   const header = { alg: 'ES256', kid: options.keyIdentifier };
-  const key = fs.readFileSync(options.privateKeyPath);
+  const key = options.privateKeyPath ? fs.readFileSync(options.privateKeyPath) : options.privateKey;
 
   return jwt.sign(claims, key, { algorithm: 'ES256', header });
 };


### PR DESCRIPTION
Adds support for passing the private key as a string instead of a file path. Solves issue https://github.com/Techofficer/node-apple-signin/issues/4