### PR TITLE
Add support for multiple apple public keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "jsonwebtoken": "^8.5.1",
-    "jwks-rsa-promisified": "^1.0.2",
+    "jwks-rsa": "^1.7.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "jsonwebtoken": "^8.5.1",
-    "node-rsa": "^1.0.5",
+    "jwks-rsa-promisified": "^1.0.2",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7"
   },

--- a/source/index.js
+++ b/source/index.js
@@ -96,7 +96,7 @@ const getApplePublicKey = async (kid) => {
 
   const data = await request({ url: url.toString(), method: 'GET' });
   const key = JSON.parse(data).keys.find(key => key.kid === kid);
-  if (!key) throw Error("Can't find apple public key");;
+  if (!key) throw new Error("Can't find apple public key");;
 
   const pubKey = new NodeRSA();
   pubKey.importKey({ n: Buffer.from(key.n, 'base64'), e: Buffer.from(key.e, 'base64') }, 'components-public');

--- a/source/index.js
+++ b/source/index.js
@@ -94,8 +94,8 @@ const getApplePublicKey = async (kid) => {
   const url = new URL(ENDPOINT_URL);
   url.pathname = '/auth/keys';
 
-  const data = await request({ url: url.toString(), method: 'GET' });
-  const key = JSON.parse(data).keys.find(key => key.kid === kid);
+  const data = await request({ url: url.toString(), method: 'GET', json: true });  
+  const key = data.keys.find(key => key.kid === kid);
   if (!key) throw new Error("Can't find apple public key");;
 
   const pubKey = new NodeRSA();


### PR DESCRIPTION
Currently we use only first public key provided by apple to verify ID
token. It seems that apple issues ID tokens with different keys (3 in
this moment). This fix uses `header.kid` field from ID token in order to
identify which public key will be used to verify ID token.