### PR TITLE
✨Make redirect_url optional in refreshAuthorizationToken

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -54,7 +54,6 @@ const getClientSecret = options => {
 
 const getAuthorizationToken = async (code, options) => {
   if (!options.clientID) throw new Error('clientID is empty');
-  if (!options.redirectUri) throw new Error('redirectUri is empty');
   if (!options.clientSecret) throw new Error('clientSecret is empty');
 
   const url = new URL(ENDPOINT_URL);


### PR DESCRIPTION
- ✨Make redirect_url optional in refreshAuthorizationToken

It's optional as can bee seen in the docs here: https://developer.apple.com/documentation/signinwithapplerestapi/generate_and_validate_tokens. I encountered the usecase with the RN library https://github.com/invertase/react-native-apple-authentication/

Thanks a lot for the awesome work!